### PR TITLE
Feature/gh pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy IG to GitHub Pages
+on:
+  workflow_run:
+    workflows: ["SUSHI Publish NHSE"]
+    branches: [development]
+    types: 
+      - completed
+
+jobs:
+  # Deploy job (see docs https://github.com/actions/deploy-pages)
+  deploy:
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
           chmod -c -R +rX "_site/" | while read line; do
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
-          
+
       - name: Publish IG to GitHub Pages
         uses: actions/upload-pages-artifact@v3
 
@@ -75,7 +75,8 @@ jobs:
   deploy:
     # Add a dependency to the build job
     needs: build
-
+    # Only deploy on development branch
+    if: github.ref == 'refs/heads/development'
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write      # to deploy to Pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,18 +55,30 @@ jobs:
           name: IG Archive
           path: ./output/
 
-      - name: Prepare files for GitHub Pages
-        run: |
-          cp -r output _site;
-          chmod -c -R +rX "_site/" | while read line; do
-            echo "::warning title=Invalid file permissions automatically fixed::$line"
-          done
-
-      - name: Publish IG to GitHub Pages
-        uses: actions/upload-pages-artifact@v3
-
       - name: Cache Node modules
         uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}--build-cache-npm-packages-${{ hashFiles('**/package-lock.json') }}
+
+  # Deploy job (https://github.com/actions/deploy-pages)
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,16 @@ jobs:
           name: IG Archive
           path: ./output/
 
+      - name: Prepare files for GitHub Pages
+        run: |
+          cp -r output _site;
+          chmod -c -R +rX "_site/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+          
+      - name: Publish IG to GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+
       - name: Cache Node modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,26 +70,3 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ runner.os }}--build-cache-npm-packages-${{ hashFiles('**/package-lock.json') }}
-
-  # Deploy job (https://github.com/actions/deploy-pages)
-  deploy:
-    # Add a dependency to the build job
-    needs: build
-    # Only deploy on development branch
-    if: github.ref == 'refs/heads/development'
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    # Specify runner + deployment step
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,16 @@ jobs:
           name: IG Archive
           path: ./output/
 
+      - name: Prepare files for GitHub Pages
+        run: |
+          cp -r output _site;
+          chmod -c -R +rX "_site/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
+      - name: Publish IG to GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+
       - name: Cache Node modules
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
@vickyjaiswal0308 

I've added steps in the build pipeline to deploy the built website to github pages.  There is a version up already 

https://declankieran-nhsd.github.io/ra-sandbox.

I've also modified it so that it will only deploy on a merge to develop.  I did have it in the same workflow as a separate job, but if with an IF to check if its the development branch, but it feels cleaner to have it as a separate workflow.  It publishes to an internal Environment location in the build, and I'm assuming the deploy workflow will be able to access it from a separate workflow, as opposed to needing to be done in the same workflow.  

To test this, I need to merge this in to make sure the second workflow is triggered when the branch is development.  The deploy workflow didn't run on the last push to this branch, so that seems to work.  If there are any issues you spot with the code, add comments in this one and I'll resolve in a new PR.