### PR TITLE
update to maintain consent object for dissent/revoke and examples

### DIFF
--- a/input/fsh/codesystem/RA-ConsentPurpose.fsh
+++ b/input/fsh/codesystem/RA-ConsentPurpose.fsh
@@ -15,3 +15,5 @@ Description: "A CodeSystem to identify the purpose of the consent given within R
 * ^caseSensitive = true
 * ^content = #complete
 * #RACONSENT "Reasonable Adjustments - Consent to record Reasonable Adjustments"
+* #RADISSENT "Reasonable Adjustments - Dissent to record Reasonable Adjustments"
+* #RAREVOKED "Reasonable Adjustments - Consent revoked to record Reasonable Adjustments"

--- a/input/fsh/examples/0030-RAConsentExampleDissent.fsh
+++ b/input/fsh/examples/0030-RAConsentExampleDissent.fsh
@@ -1,6 +1,6 @@
-Instance: RAConsentExample1
+Instance: RAConsentExampleDissent
 InstanceOf: Consent
-Title: "RA example of Consent resource where patient provides consent."
+Title: "RA example of Consent resource where patient dissents to share information."
 Usage: #example
 * meta.profile = "https://fhir.nhs.uk/England/StructureDefinition/FlagConsent"
 
@@ -12,7 +12,7 @@ Usage: #example
 * status = #active
 * scope = $consentscope#patient-privacy
 * category = PatientFlagCategory#NRAF "National Reasonable Adjustments Flag"
-* provision.purpose = RA-ConsentPurpose#RACONSENT "Reasonable Adjustments - Consent to record Reasonable Adjustments"
+* provision.purpose = RA-ConsentPurpose#RADISSENT "Reasonable Adjustments - Dissent to record Reasonable Adjustments"
 * patient = Reference(Patient/PatientExample1)
 * policy.authority = "https://www.gov.uk/"
 * policy.uri = "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/535024/data-security-review.pdf"

--- a/input/fsh/examples/0031-RAConsentExampleRevoked.fsh
+++ b/input/fsh/examples/0031-RAConsentExampleRevoked.fsh
@@ -1,6 +1,6 @@
-Instance: RAConsentExample1
+Instance: RAConsentExampleRevoked
 InstanceOf: Consent
-Title: "RA example of Consent resource where patient provides consent."
+Title: "RA example of Consent resource where patient revokes consent."
 Usage: #example
 * meta.profile = "https://fhir.nhs.uk/England/StructureDefinition/FlagConsent"
 
@@ -12,7 +12,7 @@ Usage: #example
 * status = #active
 * scope = $consentscope#patient-privacy
 * category = PatientFlagCategory#NRAF "National Reasonable Adjustments Flag"
-* provision.purpose = RA-ConsentPurpose#RACONSENT "Reasonable Adjustments - Consent to record Reasonable Adjustments"
+* provision.purpose = RA-ConsentPurpose#RAREVOKED "Reasonable Adjustments - Consent revoked to record Reasonable Adjustments"
 * patient = Reference(Patient/PatientExample1)
 * policy.authority = "https://www.gov.uk/"
 * policy.uri = "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/535024/data-security-review.pdf"
@@ -22,7 +22,7 @@ Usage: #example
 * contained.id = "4c75ce1f-1ad7-4391-b5f6-104754c7e904"
 * contained.target.reference = "#"
 * contained.recorded = "2024-01-01T11:00:00+00:00"
-* contained.activity = $v3-DataOperation#CREATE "create"
+* contained.activity = $v3-DataOperation#UPDATE "revise"
 * contained.agent.role = $CareConnect-SDSJobRoleName-1#R0260 "General Medical Practitioner"
 * contained.agent.who.reference = "https://sds.spineservices.nhs.uk/STU3/Practitioner/2ee4tr6a9"
 * contained.agent.onBehalfOf.reference = "https://directory.spineservices.nhs.uk/STU3/Organization/a3e5i7"

--- a/input/images-source/consent-sequence.plantuml
+++ b/input/images-source/consent-sequence.plantuml
@@ -30,10 +30,17 @@ alt Consent has been given
   pra <-- api : OperationOutcome
 else Consent has not been given/been revoked
   pra ->  api : Record consent was not given
-  api ->  con : Delete adjustment consent
-  api ->  pfg : Delete adjustment patient flag
-  api ->  adj : Delete adjustment flag(s)
-  api ->  cod : Delete condition flag(s)
+  api ->  con : Create/update resource
+  con ->  con : Validate
+  api <-- con : return
+  alt Validation failed
+    api -> api : rollback
+  else
+    api ->  con : Delete adjustment consent
+    api ->  pfg : Delete adjustment patient flag
+    api ->  adj : Delete adjustment flag(s)
+    api ->  cod : Delete condition flag(s)
+  end
   pra <-- api : OperationOutcome
 end
 

--- a/input/pagecontent/consent-to-share-information.md
+++ b/input/pagecontent/consent-to-share-information.md
@@ -52,7 +52,7 @@ And all conditions will be deleted
 
 ### Workflow
 
-If consent is not given, then this will be recorded.  If there was previous consent to record adjustments, but the consent is then revoked, then all adjustment records must also be removed.
+When consent or dissent is provided by the patient or their advocate, then this will be recorded in a [Consent](https://www.hl7.org/fhir/r4/consent.html) resource.  If there was previous consent to record adjustments, but the consent is then revoked, then all adjustment records must also be removed.
 
 <div>
     <img style="max-width: 100%" alt="Consent workflow BPMN diagram." src="consent-to-treatment.svg"/>
@@ -60,9 +60,9 @@ If consent is not given, then this will be recorded.  If there was previous cons
 
 ### System Interactions
 
-If consent is given either by the patient or the patient advocate, then this should be recorded.  A record of who obtained the consent must also be embedded in the Consent resource.  This will done using a provenance resource.  If consent has not been previously given, then this means the Consent resource must be created.  If consent is removed, then the Consent resource should be deleted.  The absence of a Consent resource implies patient dissent.
+If consent is given either by the patient or the patient advocate, then this should be recorded.  A record of who obtained the consent must also be embedded in the Consent resource.  This will done using a contained provenance resource.  
 
-If consent is removed, then all previous adjustment records must be deleted, including the patient flag and all adjustment flags and conditions.
+If consent has not been previously given, then this means the Consent resource must be created.  If consent is revoked, then the Consent resource should be updated to reflect this and marked as inactive.  Any previous adjustment records that were recorded must be removed, including the patient flag and all adjustment flags and conditions.
 
 <div style="text-align: left;">
 
@@ -73,5 +73,8 @@ If consent is removed, then all previous adjustment records must be deleted, inc
 ### Examples
 
 * [Consent is given example](Consent-RAConsentExample1.html)
-* Consent is not given is implied by the absence of a Consent resource
-* Consent is revoked is implied by the absence of a Consent resource
+
+**TODO** - *these were not previous modelled in the terminology*
+
+* [Consent is not given](Consent-RAConsentExampleDissent.html)
+* [Consent is revoked](Consent-RAConsentExampleRevoked.html)


### PR DESCRIPTION
@vickyjaiswal0308 @marcusfearnett-nhsdigital updates to reflect maintaining a consent object for dissent and revoking consent.

I have elaborated on the consent scenarios, i.e. separated them into better scoped features.  See https://github.com/declankieran-nhsd/cucumber-postman/blob/main/features/consent.feature for updated scenarios.  

Note, the node package that generates the collection currently only works on linux because of the paths, but I'll fix that at some point. 